### PR TITLE
fix: Correctly calculate totalPages in tiering summary

### DIFF
--- a/app/api/pages/tiers/route.ts
+++ b/app/api/pages/tiers/route.ts
@@ -189,7 +189,7 @@ async function getTieringSummary(firestore: FirebaseFirestore.Firestore): Promis
 
     const statsData = statsDoc.data();
     const distribution = (statsData?.tierDistribution || {}) as Record<string, number>;
-    const totalPages = Object.values(distribution).reduce((sum, count) => sum + count, 0);
+    const totalPages = Object.values(distribution).reduce((sum: number, count: number) => sum + count, 0);
 
     // Calculate priority breakdown by querying pages
     const prioritySnapshot = await firestore.collection('pages')


### PR DESCRIPTION
This commit fixes a TypeScript build error in the `getTieringSummary` function within the `app/api/pages/tiers/route.ts` file. The build was failing because of a type inference issue with the `reduce` function when calculating `totalPages`.

The accumulator and value in the reduce function are now explicitly typed as numbers, which provides the necessary type information to the TypeScript compiler, ensuring that `totalPages` is correctly calculated as a number and resolving the build failure.