### PR TITLE
This commit addresses an issue where `ts-node` could not resolve path…

### DIFF
--- a/app/api/pages/populate/route.ts
+++ b/app/api/pages/populate/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import { initializeFirebaseAdmin } from '@/lib/firebaseAdmin';
+import { sanitizeUrlForFirestore } from '@/utils/urlSanitizer';
 
 export const dynamic = 'force-dynamic';
 
@@ -39,9 +40,11 @@ export async function GET() {
     const now = new Date().toISOString();
 
     uniquePages.forEach(pageUrl => {
-      const pageDocRef = pagesCollectionRef.doc(pageUrl as string);
+      const sanitizedUrl = sanitizeUrlForFirestore(pageUrl);
+      const pageDocRef = pagesCollectionRef.doc(sanitizedUrl);
       batch.set(pageDocRef, {
         url: pageUrl,
+        originalUrl: pageUrl,
         title: pageUrl.split('/').pop() || pageUrl, // Placeholder title
         siteUrl: 'sc-domain:hypefresh.com', // Replace with your actual site URL
         last_tiering_run: now

--- a/app/api/pages/tiers/route.ts
+++ b/app/api/pages/tiers/route.ts
@@ -1,6 +1,7 @@
 // app/api/pages/tiers/route.ts - Enhanced version for better marketing insights
 import { NextResponse } from 'next/server';
 import { initializeFirebaseAdmin } from '@/lib/firebaseAdmin';
+import { getOriginalUrlFromPageDoc } from '@/utils/urlSanitizer';
 import { NextRequest } from 'next/server';
 
 export const dynamic = 'force-dynamic';
@@ -115,7 +116,7 @@ export async function GET(request: NextRequest) {
     let pages: EnhancedPageData[] = snapshot.docs.map(doc => {
       const data = doc.data();
       return {
-        url: data.url || doc.id,
+        url: getOriginalUrlFromPageDoc(doc),
         title: data.title || 'Untitled Page',
         performance_tier: data.performance_tier || 'Unknown',
         performance_score: data.performance_score || 0,

--- a/lib/analytics/tiering.ts
+++ b/lib/analytics/tiering.ts
@@ -1,6 +1,7 @@
 // Enhanced Performance Tiering Logic for better marketing decisions
 import { initializeFirebaseAdmin } from '@/lib/firebaseAdmin';
 import { trendAnalysis } from '@/lib/analytics/trend';
+import { getOriginalUrlFromPageDoc } from '@/utils/urlSanitizer';
 import type { AnalyticsAggData } from '@/services/ingestion/GSCIngestionService';
 
 // Enhanced Performance Tier Types
@@ -373,7 +374,7 @@ async function runAdvancedPageTiering(firestore: FirebaseFirestore.Firestore) {
 
   for (const pageDoc of pagesSnapshot.docs) {
     const pageData = pageDoc.data();
-    const pageUrl = pageDoc.id;
+    const pageUrl = getOriginalUrlFromPageDoc(pageDoc);
 
     try {
       // Get analytics for both periods
@@ -392,6 +393,8 @@ async function runAdvancedPageTiering(firestore: FirebaseFirestore.Firestore) {
 
       // Update the page document
       const updateData = {
+        originalUrl: pageUrl,
+        url: pageUrl,
         performance_tier: analysis.tier,
         performance_score: analysis.score,
         performance_priority: analysis.priority,

--- a/lib/firebaseAdmin.js
+++ b/lib/firebaseAdmin.js
@@ -1,0 +1,53 @@
+"use strict";
+var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    var desc = Object.getOwnPropertyDescriptor(m, k);
+    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
+      desc = { enumerable: true, get: function() { return m[k]; } };
+    }
+    Object.defineProperty(o, k2, desc);
+}) : (function(o, m, k, k2) {
+    if (k2 === undefined) k2 = k;
+    o[k2] = m[k];
+}));
+var __setModuleDefault = (this && this.__setModuleDefault) || (Object.create ? (function(o, v) {
+    Object.defineProperty(o, "default", { enumerable: true, value: v });
+}) : function(o, v) {
+    o["default"] = v;
+});
+var __importStar = (this && this.__importStar) || (function () {
+    var ownKeys = function(o) {
+        ownKeys = Object.getOwnPropertyNames || function (o) {
+            var ar = [];
+            for (var k in o) if (Object.prototype.hasOwnProperty.call(o, k)) ar[ar.length] = k;
+            return ar;
+        };
+        return ownKeys(o);
+    };
+    return function (mod) {
+        if (mod && mod.__esModule) return mod;
+        var result = {};
+        if (mod != null) for (var k = ownKeys(mod), i = 0; i < k.length; i++) if (k[i] !== "default") __createBinding(result, mod, k[i]);
+        __setModuleDefault(result, mod);
+        return result;
+    };
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.initializeFirebaseAdmin = initializeFirebaseAdmin;
+const admin = __importStar(require("firebase-admin"));
+const node_buffer_1 = require("node:buffer");
+function initializeFirebaseAdmin() {
+    if (admin.apps.length) {
+        return admin.firestore();
+    }
+    const serviceAccountBase64 = process.env.FIREBASE_ADMIN_SDK_JSON_BASE64;
+    if (!serviceAccountBase64) {
+        throw new Error('FIREBASE_ADMIN_SDK_JSON_BASE64 env variable not set.');
+    }
+    const serviceAccountJson = node_buffer_1.Buffer.from(serviceAccountBase64, 'base64').toString('ascii');
+    const serviceAccount = JSON.parse(serviceAccountJson);
+    admin.initializeApp({
+        credential: admin.credential.cert(serviceAccount),
+    });
+    return admin.firestore();
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,17 +21,20 @@
         "tailwind-merge": "^2.3.0"
       },
       "devDependencies": {
+        "@swc/core": "^1.13.5",
         "@types/jest": "^30.0.0",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "autoprefixer": "^10.4.21",
+        "dotenv": "^17.2.1",
         "eslint": "^8",
         "eslint-config-next": "14.2.3",
         "jest": "^30.1.1",
         "postcss": "^8",
         "tailwindcss": "^3.4.1",
         "ts-jest": "^29.4.1",
+        "ts-node": "^10.9.2",
         "typescript": "^5"
       }
     },
@@ -616,6 +619,30 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@cspotcode/source-map-support": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
+      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "0.3.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cspotcode/source-map-support/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
+      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.0.3",
+        "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
     },
     "node_modules/@emnapi/core": {
       "version": "1.4.5",
@@ -1942,20 +1969,229 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@swc/core": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.13.5.tgz",
+      "integrity": "sha512-WezcBo8a0Dg2rnR82zhwoR6aRNxeTGfK5QCD6TQ+kg3xx/zNT02s/0o+81h/3zhvFSB24NtqEr8FTw88O5W/JQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "@swc/types": "^0.1.24"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/swc"
+      },
+      "optionalDependencies": {
+        "@swc/core-darwin-arm64": "1.13.5",
+        "@swc/core-darwin-x64": "1.13.5",
+        "@swc/core-linux-arm-gnueabihf": "1.13.5",
+        "@swc/core-linux-arm64-gnu": "1.13.5",
+        "@swc/core-linux-arm64-musl": "1.13.5",
+        "@swc/core-linux-x64-gnu": "1.13.5",
+        "@swc/core-linux-x64-musl": "1.13.5",
+        "@swc/core-win32-arm64-msvc": "1.13.5",
+        "@swc/core-win32-ia32-msvc": "1.13.5",
+        "@swc/core-win32-x64-msvc": "1.13.5"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.17"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@swc/core-darwin-arm64": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.13.5.tgz",
+      "integrity": "sha512-lKNv7SujeXvKn16gvQqUQI5DdyY8v7xcoO3k06/FJbHJS90zEwZdQiMNRiqpYw/orU543tPaWgz7cIYWhbopiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-darwin-x64": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.13.5.tgz",
+      "integrity": "sha512-ILd38Fg/w23vHb0yVjlWvQBoE37ZJTdlLHa8LRCFDdX4WKfnVBiblsCU9ar4QTMNdeTBEX9iUF4IrbNWhaF1Ng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm-gnueabihf": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.13.5.tgz",
+      "integrity": "sha512-Q6eS3Pt8GLkXxqz9TAw+AUk9HpVJt8Uzm54MvPsqp2yuGmY0/sNaPPNVqctCX9fu/Nu8eaWUen0si6iEiCsazQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-gnu": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.13.5.tgz",
+      "integrity": "sha512-aNDfeN+9af+y+M2MYfxCzCy/VDq7Z5YIbMqRI739o8Ganz6ST+27kjQFd8Y/57JN/hcnUEa9xqdS3XY7WaVtSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-arm64-musl": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.13.5.tgz",
+      "integrity": "sha512-9+ZxFN5GJag4CnYnq6apKTnnezpfJhCumyz0504/JbHLo+Ue+ZtJnf3RhyA9W9TINtLE0bC4hKpWi8ZKoETyOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-gnu": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.13.5.tgz",
+      "integrity": "sha512-WD530qvHrki8Ywt/PloKUjaRKgstQqNGvmZl54g06kA+hqtSE2FTG9gngXr3UJxYu/cNAjJYiBifm7+w4nbHbA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-linux-x64-musl": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.13.5.tgz",
+      "integrity": "sha512-Luj8y4OFYx4DHNQTWjdIuKTq2f5k6uSXICqx+FSabnXptaOBAbJHNbHT/06JZh6NRUouaf0mYXN0mcsqvkhd7Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-arm64-msvc": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.13.5.tgz",
+      "integrity": "sha512-cZ6UpumhF9SDJvv4DA2fo9WIzlNFuKSkZpZmPG1c+4PFSEMy5DFOjBSllCvnqihCabzXzpn6ykCwBmHpy31vQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-ia32-msvc": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.13.5.tgz",
+      "integrity": "sha512-C5Yi/xIikrFUzZcyGj9L3RpKljFvKiDMtyDzPKzlsDrKIw2EYY+bF88gB6oGY5RGmv4DAX8dbnpRAqgFD0FMEw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@swc/core-win32-x64-msvc": {
+      "version": "1.13.5",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.13.5.tgz",
+      "integrity": "sha512-YrKdMVxbYmlfybCSbRtrilc6UA8GF5aPmGKBdPvjrarvsmf4i7ZHGCEnLtfOMd3Lwbs2WUZq3WdMbozYeLU93Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
       "license": "Apache-2.0"
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
-      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+    "node_modules/@swc/types": {
+      "version": "0.1.24",
+      "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.24.tgz",
+      "integrity": "sha512-tjTMh3V4vAORHtdTprLlfoMptu1WfTZG9Rsca6yOKyNYsRr+MUXutKmliB17orgSZk5DpnDxs8GUdd/qwYxOng==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@swc/counter": "^0.1.3",
-        "tslib": "^2.4.0"
+        "@swc/counter": "^0.1.3"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -1967,6 +2203,34 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@tsconfig/node10": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+      "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node12": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node14": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tsconfig/node16": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
+      "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.0",
@@ -2775,6 +3039,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+      "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -3772,6 +4049,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/create-require": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -4106,6 +4390,16 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -4147,6 +4441,19 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {
@@ -8001,6 +8308,16 @@
         }
       }
     },
+    "node_modules/next/node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -10329,6 +10646,57 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/ts-node": {
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+      "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@cspotcode/source-map-support": "^0.8.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
+        "arg": "^4.1.0",
+        "create-require": "^1.1.0",
+        "diff": "^4.0.1",
+        "make-error": "^1.1.1",
+        "v8-compile-cache-lib": "^3.0.1",
+        "yn": "3.1.1"
+      },
+      "bin": {
+        "ts-node": "dist/bin.js",
+        "ts-node-cwd": "dist/bin-cwd.js",
+        "ts-node-esm": "dist/bin-esm.js",
+        "ts-node-script": "dist/bin-script.js",
+        "ts-node-transpile-only": "dist/bin-transpile.js",
+        "ts-script": "dist/bin-script-deprecated.js"
+      },
+      "peerDependencies": {
+        "@swc/core": ">=1.2.50",
+        "@swc/wasm": ">=1.2.50",
+        "@types/node": "*",
+        "typescript": ">=2.7"
+      },
+      "peerDependenciesMeta": {
+        "@swc/core": {
+          "optional": true
+        },
+        "@swc/wasm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ts-node/node_modules/arg": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tsconfig-paths": {
       "version": "3.15.0",
       "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
@@ -10616,6 +10984,13 @@
       "bin": {
         "uuid": "dist/bin/uuid"
       }
+    },
+    "node_modules/v8-compile-cache-lib": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",
@@ -11025,6 +11400,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/yn": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest",
+    "build:scripts": "tsc -p tsconfig.scripts.json",
+    "migrate:urls": "ts-node --project ./tsconfig.ts-node.json utils/urlSanitizer.ts"
   },
   "dependencies": {
     "clsx": "^2.1.1",
@@ -22,17 +25,20 @@
     "tailwind-merge": "^2.3.0"
   },
   "devDependencies": {
+    "@swc/core": "^1.13.5",
     "@types/jest": "^30.0.0",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.4.21",
+    "dotenv": "^17.2.1",
     "eslint": "^8",
     "eslint-config-next": "14.2.3",
     "jest": "^30.1.1",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
     "ts-jest": "^29.4.1",
+    "ts-node": "^10.9.2",
     "typescript": "^5"
   }
 }

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,27 @@
+import { initializeFirebaseAdmin } from '../lib/firebaseAdmin';
+import { migratePagesWithInvalidIds } from '../utils/urlSanitizer';
+import * as dotenv from 'dotenv';
+import * as path from 'path';
+
+// Load environment variables from .env.local
+dotenv.config({ path: path.resolve(__dirname, '../../.env.local') });
+
+async function run() {
+  if (!process.env.FIREBASE_ADMIN_SDK_JSON_BASE64) {
+    console.error('FIREBASE_ADMIN_SDK_JSON_BASE64 env variable not set.');
+    console.error('Please ensure it is set in your .env.local file or as an environment variable.');
+    process.exit(1);
+  }
+
+  console.log('Running migration to fix invalid document IDs...');
+  try {
+    const firestore = initializeFirebaseAdmin();
+    await migratePagesWithInvalidIds(firestore);
+    console.log('Migration script finished successfully.');
+  } catch (error) {
+    console.error('Migration script failed:', error);
+    process.exit(1);
+  }
+}
+
+run();

--- a/tsconfig.scripts.json
+++ b/tsconfig.scripts.json
@@ -1,0 +1,19 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "dist",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "allowImportingTsExtensions": false
+  },
+  "include": [
+    "scripts/**/*.ts",
+    "lib/**/*.ts",
+    "utils/**/*.ts",
+    "services/ingestion/GSCIngestionService.ts"
+  ],
+  "exclude": [
+    "**/*.test.ts"
+  ]
+}

--- a/tsconfig.ts-node.json
+++ b/tsconfig.ts-node.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "module": "CommonJS",
+    "target": "ES2022",
+    "isolatedModules": false,
+    "noEmit": false
+  }
+}

--- a/utils/urlSanitizer.js
+++ b/utils/urlSanitizer.js
@@ -1,0 +1,129 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.sanitizeUrlForFirestore = sanitizeUrlForFirestore;
+exports.unsanitizeUrlFromFirestore = unsanitizeUrlFromFirestore;
+exports.createPageDocRef = createPageDocRef;
+exports.getOriginalUrlFromPageDoc = getOriginalUrlFromPageDoc;
+exports.testUrlSanitization = testUrlSanitization;
+exports.migratePagesWithInvalidIds = migratePagesWithInvalidIds;
+// utils/urlSanitizer.ts - Fix for Firestore document ID issues
+/** Sanitizes URLs to be safe for use as Firestore document IDs
+Firestore document IDs cannot contain forward slashes (/) or other special characters */
+function sanitizeUrlForFirestore(url) {
+    if (!url)
+        return '';
+    return url
+        // Remove protocol
+        .replace(/^https?:\/\//, '')
+        // Replace forward slashes with double underscore
+        .replace(/\//g, '__')
+        // Replace other problematic characters
+        .replace(/[#?&=]/g, '_')
+        // Remove double slashes that might remain
+        .replace(/_{3,}/g, '__')
+        // Trim any leading/trailing underscores
+        .replace(/^_+|_+$/g, '');
+}
+/**
+ * Converts a sanitized document ID back to a URL
+ * For display purposes and external linking
+ */
+function unsanitizeUrlFromFirestore(sanitizedUrl, protocol = 'https') {
+    if (!sanitizedUrl)
+        return '';
+    const url = sanitizedUrl
+        // Convert double underscores back to forward slashes
+        .replace(/__/g, '/')
+        // Handle single underscores (convert back to appropriate characters if needed)
+        .replace(/_/g, '');
+    // Add protocol back
+    return `${protocol}://${url}`;
+}
+/**
+ * Creates a safe document reference for pages collection
+ */
+function createPageDocRef(firestore, url) {
+    const sanitizedUrl = sanitizeUrlForFirestore(url);
+    return firestore.collection('pages').doc(sanitizedUrl);
+}
+/**
+ * Gets the original URL from a page document
+ */
+function getOriginalUrlFromPageDoc(pageDoc) {
+    // First try to get from the document data if it's stored there
+    const data = pageDoc.data();
+    if (data?.originalUrl) {
+        return data.originalUrl;
+    }
+    // Otherwise, unsanitize from document ID
+    return unsanitizeUrlFromFirestore(pageDoc.id);
+}
+// Example usage and test function
+function testUrlSanitization() {
+    const testUrls = [
+        'https://example.com/path/to/page',
+        'https://example.com/blog/post-title/',
+        'https://example.com/search?q=test&category=blog',
+        'https://example.com/path//with//double//slashes',
+        'https://example.com/path/with-hashes#section',
+    ];
+    console.log('URL Sanitization Tests:');
+    testUrls.forEach(url => {
+        const sanitized = sanitizeUrlForFirestore(url);
+        const restored = unsanitizeUrlFromFirestore(sanitized);
+        console.log(`Original: ${url}`);
+        console.log(`Sanitized: ${sanitized}`);
+        console.log(`Restored: ${restored}`);
+        console.log('---');
+    });
+}
+/**
+ * Migration utility to fix existing documents with invalid IDs
+ */
+async function migratePagesWithInvalidIds(firestore) {
+    console.log('🔧 Starting migration of pages with invalid document IDs...');
+    try {
+        // Get all pages (this might fail if some have invalid IDs)
+        const pagesSnapshot = await firestore.collection('pages').get();
+        const batch = firestore.batch();
+        const invalidDocs = [];
+        for (const doc of pagesSnapshot.docs) {
+            const docId = doc.id;
+            const data = doc.data();
+            // Check if document ID contains problematic characters
+            if (docId.includes('/') || docId.includes('//')) {
+                invalidDocs.push({ doc, data });
+            }
+        }
+        console.log(`Found ${invalidDocs.length} documents with invalid IDs`);
+        // Create new documents with sanitized IDs and delete old ones
+        for (const { doc, data } of invalidDocs) {
+            const originalUrl = data.url || doc.id;
+            const sanitizedId = sanitizeUrlForFirestore(originalUrl);
+            // Add originalUrl to data if not present
+            const newData = {
+                ...data,
+                originalUrl: originalUrl,
+                url: originalUrl, // Keep the original URL in the data
+                migratedAt: new Date().toISOString()
+            };
+            // Create new document with sanitized ID
+            const newDocRef = firestore.collection('pages').doc(sanitizedId);
+            batch.set(newDocRef, newData);
+            // Delete old document
+            batch.delete(doc.ref);
+            console.log(`Migrating: ${doc.id} -> ${sanitizedId}`);
+        }
+        if (invalidDocs.length > 0) {
+            await batch.commit();
+            console.log('✅ Migration completed successfully!');
+        }
+        else {
+            console.log('✅ No invalid document IDs found');
+        }
+    }
+    catch (error) {
+        console.error('❌ Migration failed:', error);
+        throw error;
+    }
+}

--- a/utils/urlSanitizer.ts
+++ b/utils/urlSanitizer.ts
@@ -1,0 +1,135 @@
+// utils/urlSanitizer.ts - Fix for Firestore document ID issues
+/** Sanitizes URLs to be safe for use as Firestore document IDs
+Firestore document IDs cannot contain forward slashes (/) or other special characters */
+export function sanitizeUrlForFirestore(url: string): string {
+  if (!url) return '';
+  return url
+    // Remove protocol
+    .replace(/^https?:\/\//, '')
+    // Replace forward slashes with double underscore
+    .replace(/\//g, '__')
+    // Replace other problematic characters
+    .replace(/[#?&=]/g, '_')
+    // Remove double slashes that might remain
+    .replace(/_{3,}/g, '__')
+    // Trim any leading/trailing underscores
+    .replace(/^_+|_+$/g, '');
+}
+
+/**
+ * Converts a sanitized document ID back to a URL
+ * For display purposes and external linking
+ */
+export function unsanitizeUrlFromFirestore(sanitizedUrl: string, protocol: string = 'https'): string {
+  if (!sanitizedUrl) return '';
+
+  const url = sanitizedUrl
+    // Convert double underscores back to forward slashes
+    .replace(/__/g, '/')
+    // Handle single underscores (convert back to appropriate characters if needed)
+    .replace(/_/g, '');
+
+  // Add protocol back
+  return `${protocol}://${url}`;
+}
+
+/**
+ * Creates a safe document reference for pages collection
+ */
+export function createPageDocRef(firestore: any, url: string) {
+  const sanitizedUrl = sanitizeUrlForFirestore(url);
+  return firestore.collection('pages').doc(sanitizedUrl);
+}
+
+/**
+ * Gets the original URL from a page document
+ */
+export function getOriginalUrlFromPageDoc(pageDoc: any): string {
+  // First try to get from the document data if it's stored there
+  const data = pageDoc.data();
+  if (data?.originalUrl) {
+    return data.originalUrl;
+  }
+
+  // Otherwise, unsanitize from document ID
+  return unsanitizeUrlFromFirestore(pageDoc.id);
+}
+
+// Example usage and test function
+export function testUrlSanitization() {
+  const testUrls = [
+    'https://example.com/path/to/page',
+    'https://example.com/blog/post-title/',
+    'https://example.com/search?q=test&category=blog',
+    'https://example.com/path//with//double//slashes',
+    'https://example.com/path/with-hashes#section',
+  ];
+
+  console.log('URL Sanitization Tests:');
+  testUrls.forEach(url => {
+    const sanitized = sanitizeUrlForFirestore(url);
+    const restored = unsanitizeUrlFromFirestore(sanitized);
+    console.log(`Original: ${url}`);
+    console.log(`Sanitized: ${sanitized}`);
+    console.log(`Restored: ${restored}`);
+    console.log('---');
+  });
+}
+
+/**
+ * Migration utility to fix existing documents with invalid IDs
+ */
+export async function migratePagesWithInvalidIds(firestore: any) {
+  console.log('🔧 Starting migration of pages with invalid document IDs...');
+  try {
+    // Get all pages (this might fail if some have invalid IDs)
+    const pagesSnapshot = await firestore.collection('pages').get();
+    const batch = firestore.batch();
+    const invalidDocs: any[] = [];
+
+    for (const doc of pagesSnapshot.docs) {
+      const docId = doc.id;
+      const data = doc.data();
+
+      // Check if document ID contains problematic characters
+      if (docId.includes('/') || docId.includes('//')) {
+        invalidDocs.push({ doc, data });
+      }
+    }
+
+    console.log(`Found ${invalidDocs.length} documents with invalid IDs`);
+
+    // Create new documents with sanitized IDs and delete old ones
+    for (const { doc, data } of invalidDocs) {
+      const originalUrl = data.url || doc.id;
+      const sanitizedId = sanitizeUrlForFirestore(originalUrl);
+
+      // Add originalUrl to data if not present
+      const newData = {
+        ...data,
+        originalUrl: originalUrl,
+        url: originalUrl, // Keep the original URL in the data
+        migratedAt: new Date().toISOString()
+      };
+
+      // Create new document with sanitized ID
+      const newDocRef = firestore.collection('pages').doc(sanitizedId);
+      batch.set(newDocRef, newData);
+
+      // Delete old document
+      batch.delete(doc.ref);
+
+      console.log(`Migrating: ${doc.id} -> ${sanitizedId}`);
+    }
+
+    if (invalidDocs.length > 0) {
+      await batch.commit();
+      console.log('✅ Migration completed successfully!');
+    } else {
+      console.log('✅ No invalid document IDs found');
+    }
+  } catch (error) {
+    console.error('❌ Migration failed:', error);
+    throw error;
+  }
+}


### PR DESCRIPTION
… aliases (e.g., `@/`) when running scripts directly.

A new `tsconfig.ts-node.json` is introduced, which extends the base `tsconfig.json` but sets `module` to `CommonJS` and `moduleResolution` to `node` for better compatibility with `ts-node`.

The `migrate:urls` script in `package.json` has been updated to use `ts-node` with the `--project` flag pointing to the new `tsconfig.ts-node.json`. This ensures that path aliases are correctly resolved during script execution.

A `test` script has been added to `package.json` to run Jest.