### PR TITLE
feat: Update vercel.json with new cron job configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,12 +1,12 @@
 {
   "crons": [
     {
-      "path": "/api/cron/ingest?secret=1Kk8_ArD8PL5",
-      "schedule": "0 2 * * *"
+      "path": "/api/cron/ingest",
+      "schedule": "0 6 * * *"
     },
     {
-      "path": "/api/cron/daily-stats?secret=1Kk8_ArD8PL5",
-      "schedule": "0 3 * * *"
+      "path": "/api/cron/smart-analytics",
+      "schedule": "0 8 */3 * *"
     }
   ]
 }


### PR DESCRIPTION
This commit updates the `vercel.json` file to define two cron jobs:
- `/api/cron/ingest` running daily at 6 AM.
- `/api/cron/smart-analytics` running every 3 days at 8 AM.