### PR TITLE
Fix: Add AuthProvider to fix context-related crash

### DIFF
--- a/components/layout/DashboardLayout.tsx
+++ b/components/layout/DashboardLayout.tsx
@@ -1,41 +1,24 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { onAuthStateChanged, User } from 'firebase/auth';
-import { auth } from '@/lib/firebase';
+import React from 'react';
 import { ICONS } from '@/components/icons';
 import FirebaseDebug from '../FirebaseDebug';
+import { AuthProvider, useAuth } from '@/contexts/auth-context';
 
 interface DashboardLayoutProps {
   children: React.ReactNode;
 }
 
-const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
-  const [user, setUser] = useState<User | null>(null);
-  const [loading, setLoading] = useState(true);
-  const router = useRouter();
+const navItems = [
+  { name: 'Dashboard', icon: ICONS.DASHBOARD, href: '#' },
+  { name: 'Reports', icon: ICONS.REPORTS, href: '#' },
+  { name: 'Performance Tiers', icon: ICONS.REPORTS, href: '/performance' },
+  { name: 'AI Companion', icon: ICONS.AI_COMPANION, href: '#' },
+  { name: 'Settings', icon: ICONS.SETTINGS, href: '#' },
+];
 
-  useEffect(() => {
-    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
-      if (currentUser) {
-        setUser(currentUser);
-      } else {
-        router.push('/login');
-      }
-      setLoading(false);
-    });
-
-    return () => unsubscribe();
-  }, [router]);
-
-  const navItems = [
-    { name: 'Dashboard', icon: ICONS.DASHBOARD, href: '#' },
-    { name: 'Reports', icon: ICONS.REPORTS, href: '#' },
-    { name: 'Performance Tiers', icon: ICONS.REPORTS, href: '/performance' },
-    { name: 'AI Companion', icon: ICONS.AI_COMPANION, href: '#' },
-    { name: 'Settings', icon: ICONS.SETTINGS, href: '#' },
-  ];
+const DashboardLayoutContent: React.FC<DashboardLayoutProps> = ({ children }) => {
+  const { user, loading } = useAuth();
 
   if (loading) {
     return <div>Loading...</div>;
@@ -60,8 +43,8 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
                   href={item.href}
                   className={`flex items-center space-x-3 p-3 rounded-md transition-colors duration-200 ${
                     item.name === 'Dashboard'
-                    ? 'bg-blue-600 text-white'
-                    : 'text-gray-400 hover:bg-gray-700 hover:text-white'
+                      ? 'bg-blue-600 text-white'
+                      : 'text-gray-400 hover:bg-gray-700 hover:text-white'
                   }`}
                 >
                   {item.icon}
@@ -77,6 +60,14 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
         {children}
       </main>
     </div>
+  );
+};
+
+const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
+  return (
+    <AuthProvider>
+      <DashboardLayoutContent>{children}</DashboardLayoutContent>
+    </AuthProvider>
   );
 };
 

--- a/contexts/auth-context.tsx
+++ b/contexts/auth-context.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import { onAuthStateChanged, User } from 'firebase/auth';
+import { auth } from '@/lib/firebase';
+import { useRouter } from 'next/navigation';
+
+interface AuthContextType {
+  user: User | null;
+  loading: boolean;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const router = useRouter();
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (currentUser) => {
+      if (currentUser) {
+        setUser(currentUser);
+      } else {
+        router.push('/login');
+      }
+      setLoading(false);
+    });
+
+    return () => unsubscribe();
+  }, [router]);
+
+  return (
+    <AuthContext.Provider value={{ user, loading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}


### PR DESCRIPTION
This commit introduces an `AuthProvider` and an `AuthContext` to manage the application's authentication state.

Previously, the authentication state was managed directly within the `DashboardLayout` component. This caused a crash in child components that tried to access the authentication context, as it was not being provided to them.

This commit refactors the authentication logic into a dedicated `AuthProvider` component. The `DashboardLayout` now wraps its children with this provider, ensuring that the authentication context is available to all components in the dashboard. This resolves the crash and improves the overall structure of the code by centralizing authentication management.